### PR TITLE
Updated Compatibility for 2021

### DIFF
--- a/V2/platformio.ini
+++ b/V2/platformio.ini
@@ -9,8 +9,12 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:nucleo_f746zg]
-platform = ststm32
+platform = ststm32@~5.3.0 
 board = nucleo_f746zg
 framework = mbed
 
 build_flags = -D PIO_FRAMEWORK_MBED_RTOS_PRESENT
+
+; Note as of 15/10/21 line 12 was change from ststm32 to ststm32@~5.3.0 so that new members can pull the correct mbed version
+; You will also need to update the compat.py file's code from here https://github.com/python-intelhex/intelhex/pull/46/files
+; The location for the file: C:\Users\<user>\.platformio\packages\framework-mbed@5.51105.190312\platformio\package_deps\py3\intelhex


### PR DESCRIPTION
Updated platform to use an older version of mbed; this allows the serial communication to function properly.  Due to Python3 an intelhex file in the user's directly has to have a line of code changed.